### PR TITLE
Add News command

### DIFF
--- a/chat-plugins/info.js
+++ b/chat-plugins/info.js
@@ -17,7 +17,18 @@
 
 /** @type {ChatCommands} */
 const commands = {
-
+	
+	news: function (target, room, user) {
+		if (target) {
+			if (!this.can('addfaq')) return false;
+			room.newsbox = (target);
+			room.chatRoomData.newsbox = (target);
+			this.sendReplyBox(`<div> The newsbox has been updated to: <br />` + room.newsbox + `</div>`);
+		} else if ((!room.chatRoomData.newsbox) && this.runBroadcast()) {
+			this.sendReply('There are no announcements.');
+		} else if (this.runBroadcast()) this.sendReplyBox(`<div>` + room.chatRoomData.newsbox + `</div>`);
+	},
+	
 	'!whois': true,
 	ip: 'whois',
 	rooms: 'whois',


### PR DESCRIPTION
A basic command that works like /roomintro, but doesn't show up when a user joins a room; `/news` to view and `/news (text)` to edit. Since I haven't fully gotten the hang of writing commands please be careful—if you type `/news ` with anything after it, and if you have sufficient permissions, it will overwrite the news, and it does not return the source html. Therefore if you typed a bunch of spaces the news box would become a blank box. I will work on this more but it's something for now
(EDIT) P.S. I tested this on localhosted server, its basic functionality does work but I'm not saying there aren't loopholes or exploits that could be used to cause problems